### PR TITLE
chore: bump androidx.test.ext:junit, consolidate navigation & ksp version refs

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-androidxTestExtJunitVersion = "1.2.1"
+androidxTestExtJunitVersion = "1.3.0"  # bumped from 1.2.1 to address available update
 appcompatVersion = "1.7.0"
 constraintLayoutVersion = "2.2.1"
 coreKtxVersion = "1.15.0"
@@ -13,11 +13,12 @@ kotlinxCoroutinesTestVersion = "1.8.0"
 legacySupportV4 = "1.0.0"
 lifecycleVersion = "2.8.7"
 mockkVersion = "1.13.8"
-navigation = "2.8.9"
 navVersion = "2.8.9"
 preferenceVersion = "1.2.1"
 roomVersion = "2.6.1"
 hilt = "2.57.2"
+
+kspVersion = "2.1.20-1.0.32"
 
 [libraries]
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompatVersion" }
@@ -40,12 +41,12 @@ junit = { module = "junit:junit", version.ref = "junitVersion" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlinStdlibVersion" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTestVersion" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockkVersion" }
-navigation-safe-args = { module = "androidx.navigation:navigation-safe-args-gradle-plugin", version.ref = "navigation" }
+navigation-safe-args = { module = "androidx.navigation:navigation-safe-args-gradle-plugin", version.ref = "navVersion" }
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
 hilt-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "hilt" }
 hilt-android-testing = { module = "com.google.dagger:hilt-android-testing", version.ref = "hilt" }
 
 [plugins]
-ksp = { id = "com.google.devtools.ksp", version = "2.1.20-1.0.32" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "kspVersion" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }


### PR DESCRIPTION
 - Bump androidxTestExtJunitVersion to 1.3.0
 - Consolidate navigation keys to use navVersion
 - Add kspVersion and switch ksp plugin to use version.ref

Closes #31