### PR TITLE
docs: add requirements and roadmap for reminders

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,24 @@
 
 **MyFriendz** is an Android application designed to help you stay connected with your friends by sending timely reminders to reach out. In our fast-paced lives, it's easy to lose touch; MyFriendz ensures that doesn't happen.
 
-## Features
+## Current Features
 
-* 📇 **Contact Management**: Add and manage a list of friends you want to keep in touch with.
-* ⏰ **Custom Reminders**: Set personalized intervals (e.g., weekly, monthly) for each contact.
-* 🔔 **Notifications**: Receive alerts when it's time to reconnect.
-* 📊 **Interaction History**: Log and view past interactions to track your communication.
-* 🎨 **User-Friendly Interface**: Clean and intuitive design for seamless navigation.
+* 📇 **Contact Management**: Add, edit, delete, and view friends you want to keep in touch with.
+* 🗓️ **Last Contacted Tracking**: Store when a friend was last contacted and update that date when marking them as contacted.
+* 📱 **Contact Details**: Store phone, email, comments, and a reminder-frequency value for each friend.
+* 🎨 **User-Friendly Interface**: Clean Android UI built with Fragments, Navigation, Data Binding, Room, and Hilt.
+
+## Roadmap
+
+The product roadmap expands MyFriendz from a contact tracker into a relationship reminder app:
+
+* ⏰ **Scheduled Reminders**: Calculate due/upcoming friends from each friend’s contact cadence.
+* 🔔 **Android System Notifications**: Use Android-supported background scheduling and notification channels to remind the user when friends are due for contact.
+* 📊 **Interaction History**: Persist and display a chronological history of contacted events.
+* 💬 **External Communication Actions**: Launch external apps such as Phone, SMS, email, WhatsApp, or another compatible Android app from friend detail/reminder flows.
+* 🚀 **Future In-App Communication**: Leave room for in-app chat/calling once backend, identity, privacy, and media infrastructure are designed.
+
+See [`docs/system-requirements.md`](docs/system-requirements.md) and [`docs/feature-roadmap.md`](docs/feature-roadmap.md) for the detailed requirements and phased delivery plan. Local verification notes live in [`docs/development-notes.md`](docs/development-notes.md).
 
 ## Getting Started
 
@@ -39,16 +50,17 @@
 1. **Add Friends:**
 
     * Tap the "+" button to add a new contact.
-    * Enter the friend's name and select the desired reminder interval.
+    * Enter the friend’s name and contact details.
+    * Set or record the friend’s contact cadence/last-contacted information where supported by the current UI.
 
-2. **View Reminders:**
+2. **Manage Friends:**
 
-    * The home screen displays upcoming reminders.
-    * Tap on a contact to view interaction history or edit details.
+    * Use the home screen to view saved friends.
+    * Tap a friend to view details, edit information, delete the friend, or mark the friend as contacted.
 
-3. **Log Interactions:**
+3. **Planned Reminder Workflow:**
 
-    * After connecting with a friend, log the interaction to reset the reminder timer.
+    * Future versions will show due/upcoming reminders, schedule background reminder checks, send Android system notifications, and record a contacted history timeline.
 
 ## Project Structure
 

--- a/docs/development-notes.md
+++ b/docs/development-notes.md
@@ -1,0 +1,33 @@
+# MyFriendz Development Notes
+
+## Purpose
+
+This document captures local development and verification notes that are useful to maintainers but should not clutter the public README.
+
+## Local verification
+
+The project is an Android/Kotlin app that targets Java 17 bytecode. Local command-line verification requires a Java runtime/JDK available to the shell.
+
+Recommended command once Java/JDK is configured:
+
+```bash
+bash ./gradlew testReleaseUnitTest
+```
+
+Use Android Studio for normal IDE builds and emulator/device runs.
+
+## NextCloud-mounted workspace note
+
+When the repository is checked out under the user’s NextCloud-mounted project folder, the mount can make `gradlew` executable-bit metadata appear modified or prevent direct `./gradlew` execution.
+
+If direct wrapper execution fails, run Gradle through Bash instead:
+
+```bash
+bash ./gradlew testReleaseUnitTest
+```
+
+If Git status is polluted only by a mode-only `gradlew` difference, treat that as local environment noise rather than an application-code change. Do not commit `gradlew` mode-only changes unless intentionally fixing wrapper metadata outside the NextCloud mount.
+
+## Current implementation baseline
+
+As of the requirements baseline in `docs/system-requirements.md`, the app currently focuses on local friend CRUD/details flows. Scheduled reminder delivery, Android system notifications, and persisted interaction history are roadmap features, not completed implementation.

--- a/docs/feature-roadmap.md
+++ b/docs/feature-roadmap.md
@@ -1,0 +1,185 @@
+# MyFriendz Feature Roadmap
+
+## Purpose
+
+This roadmap translates the system requirements into implementation phases. It separates current app behavior from near-term product commitments and future platform expansion.
+
+## Current baseline
+
+The current app is a local-first Android contact tracker with friend CRUD and basic last-contacted data. It does not yet implement scheduled reminders, Android notifications, or persisted interaction history.
+
+## Phase 0 — Stabilize implementation foundation
+
+Status: already approved separately in the maintenance board.
+
+Goals:
+
+- Configure the host/JDK/Gradle verification path.
+- Add state/error coverage for add/edit/detail ViewModels.
+- Align dispatcher injection across coroutine ViewModels.
+
+Why this comes first:
+
+- Reminder/history work will touch ViewModels, domain use cases, Room, and background workers.
+- A stable test/dispatcher foundation reduces regression risk.
+
+## Phase 1 — Requirements and documentation baseline
+
+Status: this documentation task.
+
+Deliverables:
+
+- `docs/system-requirements.md`
+- `docs/feature-roadmap.md`
+- Existing vs future feature inventory.
+- System requirements suitable for implementation planning and acceptance checks.
+
+Acceptance criteria:
+
+- Existing features are identified.
+- Required reminder, notification, history, and external communication features are documented.
+- Future in-app chat/calling is documented as roadmap work, not implied current behavior.
+
+## Phase 2 — Reminder domain model and due/upcoming UI
+
+Goal:
+
+Create the local data and domain foundation for reminders before background scheduling.
+
+Candidate implementation tasks:
+
+1. Replace or wrap raw `Friend.frequency: String` with a validated reminder cadence model.
+2. Add due-date calculation in the domain layer.
+3. Add tests for due-date calculations:
+   - due today
+   - overdue
+   - not due yet
+   - weekly cadence
+   - monthly cadence
+   - custom-day cadence
+4. Show due/upcoming status in the friend list and detail screen.
+5. Keep this phase free of Android notification behavior.
+
+Acceptance criteria:
+
+- The app can compute and display a friend’s next contact due date.
+- Invalid cadence values are handled deterministically.
+- Due/upcoming state is tested without Android framework dependencies.
+
+## Phase 3 — Interaction history
+
+Goal:
+
+Persist and display contacted history.
+
+Candidate implementation tasks:
+
+1. Add `ContactInteraction` or `InteractionHistory` Room entity.
+2. Add DAO queries for:
+   - insert interaction
+   - list interactions for friend ordered newest-first
+   - delete/cascade handling for friend deletion
+3. Add repository and use-case methods.
+4. Update “mark contacted” behavior so it creates a history event and updates `Friend.lastContacted`.
+5. Add UI for logging an interaction with channel and optional notes.
+6. Add UI for viewing a friend’s history timeline.
+
+Acceptance criteria:
+
+- Interactions persist across app restarts.
+- Each friend detail screen can show interaction history.
+- Marking as contacted updates both history and last-contacted date.
+- Tests cover success and deletion/missing-friend behavior.
+
+## Phase 4 — Android scheduled reminders and system notifications
+
+Goal:
+
+Deliver Android system notifications for due friends.
+
+Candidate implementation tasks:
+
+1. Add WorkManager dependency and scheduler abstraction.
+2. Create a due-reminder worker that queries Room for due friends.
+3. Create notification channel setup.
+4. Handle Android 13+ notification permission flow.
+5. Create reminder notifications with deep links to friend details.
+6. Prevent duplicate notification spam for the same due friend/window.
+7. Add manual verification documentation for Android background behavior.
+
+Acceptance criteria:
+
+- A due friend can trigger an Android system notification.
+- Notification tap opens the correct friend or app screen.
+- Missing notification permission is handled gracefully.
+- Duplicate notification behavior is controlled.
+- Tests cover pure due-selection logic; manual verification covers OS notification delivery.
+
+## Phase 5 — External app communication actions
+
+Goal:
+
+Let users initiate communication from MyFriendz through apps already installed on the device.
+
+Candidate implementation tasks:
+
+1. Add communication action model:
+   - phone
+   - SMS/text
+   - email
+   - WhatsApp
+   - other compatible external apps later
+2. Add domain/presentation logic to expose only available actions based on friend data.
+3. Add Android intent handlers for:
+   - dialer/phone
+   - SMS
+   - email
+   - WhatsApp/generic messaging
+4. Add graceful fallbacks when data is missing or an app is unavailable.
+5. Prompt user to log an interaction after launching an external communication action.
+
+Acceptance criteria:
+
+- Phone/SMS/email actions launch appropriate external apps when data exists.
+- WhatsApp action launches when supported and fails gracefully when unavailable.
+- The app does not automatically claim contact occurred just because an external app was opened.
+- User can log the resulting interaction.
+
+## Phase 6 — Future in-app communication infrastructure
+
+Goal:
+
+Prepare for in-app chat/calling when product, backend, account, and privacy requirements exist.
+
+Future requirements to define before implementation:
+
+- Identity and sign-in model.
+- Friend/account matching.
+- Backend service and storage architecture.
+- Push notification architecture.
+- Message encryption/privacy policy.
+- Abuse/moderation/reporting model.
+- Audio/video calling provider or protocol.
+- Offline and sync behavior.
+
+Acceptance criteria for starting this phase:
+
+- Backend architecture is selected.
+- Security/privacy requirements are approved.
+- In-app communication is explicitly split from local reminder/history functionality.
+
+## Recommended implementation order
+
+1. Phase 0: foundation cleanup.
+2. Phase 1: requirements/docs baseline.
+3. Phase 2: local reminder calculation and due UI.
+4. Phase 3: interaction history.
+5. Phase 4: scheduled Android notifications.
+6. Phase 5: external app communication actions.
+7. Phase 6: future in-app communication.
+
+## Notes
+
+- Android system notifications and external app intents should be implemented before in-app chat/calling.
+- The interaction-history model should be designed now to support future channels like `IN_APP_CHAT` and `IN_APP_CALL` without requiring a second history system.
+- WorkManager is the preferred reminder scheduling baseline unless exact-time reminders become a hard product requirement.

--- a/docs/system-requirements.md
+++ b/docs/system-requirements.md
@@ -1,0 +1,238 @@
+# MyFriendz System Requirements
+
+## Document control
+
+- Project: `myfriendz`
+- Repository path: `/home/egarcia/NextCloud/Documents/Projects/Code/myfriendz`
+- Status: Draft requirements baseline
+- Last updated: 2026-05-31
+- Source of truth: Product direction provided by Erick Garcia plus current source-tree inspection
+
+## 1. Purpose
+
+MyFriendz helps users maintain relationships by tracking friends, remembering when they were last contacted, scheduling future contact reminders, showing Android system notifications when follow-up is due, and preserving a history of interactions.
+
+The current app already supports friend management and stores friend metadata. This document distinguishes existing behavior from required future behavior so implementation work can be planned, tested, and accepted like an industry software project.
+
+## 2. Scope
+
+### 2.1 In scope
+
+- Friend/contact management.
+- Reminder cadence per friend.
+- Scheduled reminders and Android system notifications.
+- Contacted/interactions history.
+- External communication handoff through installed apps such as Phone, SMS, email, WhatsApp, or other supported Android intent handlers.
+- Future in-app communication infrastructure for chat/calling when backend/media infrastructure exists.
+- Requirements, roadmap, and implementation planning documentation under `docs/`.
+
+### 2.2 Out of scope for the first reminder/history implementation
+
+- A custom backend service.
+- Real-time in-app chat.
+- In-app voice/video calling.
+- Cross-device sync.
+- Social graph import.
+- AI message drafting or relationship scoring.
+
+These are future roadmap capabilities and should not block the first local-first Android implementation.
+
+## 3. Stakeholders and user roles
+
+- Primary user: a person who wants to remember to contact friends on a recurring cadence.
+- Friend/contact: the person being tracked inside the app; not an app user unless future sharing/sync features are added.
+- Android OS: owns notification permission, notification delivery, background scheduling constraints, and external-app intent routing.
+- External communication apps: Phone, SMS, email client, WhatsApp, and other apps capable of handling Android communication intents.
+
+## 4. Existing system inventory
+
+Current source-tree inspection shows the app has:
+
+- Android app module using Kotlin, Room, Hilt, Navigation, and Data Binding.
+- `Friend` Room entity with fields:
+  - `name`
+  - `lastContacted`
+  - `frequency` as `String`
+  - `phone`
+  - `email`
+  - `comments`
+  - generated `uuid`
+- `FriendDao` CRUD operations.
+- `FriendRepository` / `FriendRepositoryImpl` data access boundary.
+- `FriendUseCase` with friend operations, including `updateFriendAsContacted(friend)` which updates `lastContacted` to `LocalDate.now()`.
+- List, add, edit, and detail screens.
+
+Current scan did not find:
+
+- A notification/reminder scheduler.
+- Android notification channel setup.
+- Runtime notification permission handling.
+- WorkManager or AlarmManager integration.
+- An interaction-history Room entity/table.
+- UI for viewing a chronological interaction timeline.
+- UI or domain layer for launching communication actions.
+
+## 5. Product capability map
+
+### 5.1 Existing capabilities
+
+- FR-EX-001: The system shall allow the user to create friend records.
+- FR-EX-002: The system shall allow the user to edit friend records.
+- FR-EX-003: The system shall allow the user to delete friend records.
+- FR-EX-004: The system shall display a list of friends.
+- FR-EX-005: The system shall display friend details.
+- FR-EX-006: The system shall store a friend's last-contacted date.
+- FR-EX-007: The system shall store friend phone, email, comments, and a reminder-frequency value.
+- FR-EX-008: The system shall support marking a friend as contacted by updating `lastContacted`.
+
+### 5.2 Required near-term capabilities
+
+- FR-REM-001: The system shall allow the user to configure a reminder cadence for each friend.
+- FR-REM-002: The system shall calculate the next due date for each friend from `lastContacted` and the configured cadence.
+- FR-REM-003: The system shall identify friends who are due or overdue for contact.
+- FR-REM-004: The system shall schedule background checks for due reminders using an Android-supported scheduling mechanism.
+- FR-REM-005: The system shall show Android system notifications for friends who are due for contact.
+- FR-REM-006: The system shall provide notification actions or deep links that open the relevant friend detail screen.
+- FR-REM-007: The system shall handle Android notification runtime permission requirements.
+- FR-REM-008: The system shall avoid duplicate reminder notifications for the same friend and due window.
+- FR-REM-009: The system shall allow a user to mark a reminder as contacted, snoozed, or dismissed if these actions are supported in the UI/notification flow.
+
+### 5.3 Required interaction-history capabilities
+
+- FR-HIST-001: The system shall persist contact/interactions as history records linked to a friend.
+- FR-HIST-002: Each interaction record shall include at minimum friend ID, timestamp/date, contact channel, and optional notes.
+- FR-HIST-003: The system shall allow the user to log an interaction manually.
+- FR-HIST-004: Marking a friend as contacted shall create an interaction-history record.
+- FR-HIST-005: The system shall display a friend’s interaction history in reverse chronological order.
+- FR-HIST-006: The system shall update the friend’s `lastContacted` value from the most recent contact interaction.
+- FR-HIST-007: Deleting a friend shall deterministically handle associated interaction-history records, either by cascade delete or by a documented retention policy.
+
+### 5.4 Required external communication capabilities
+
+- FR-COMM-001: The system shall allow the user to initiate a phone call through an external app when a friend has a phone number.
+- FR-COMM-002: The system shall allow the user to initiate an SMS/text message through an external app when a friend has a phone number.
+- FR-COMM-003: The system shall allow the user to initiate an email through an external app when a friend has an email address.
+- FR-COMM-004: The system shall allow the user to open WhatsApp or another compatible messaging app through Android intents when supported by installed apps and available contact data.
+- FR-COMM-005: The system shall show clear disabled states or errors when a requested external communication channel is unavailable.
+- FR-COMM-006: The system shall optionally prompt the user to log an interaction after returning from an external communication action.
+
+### 5.5 Future in-app communication capabilities
+
+- FR-FUT-001: The architecture shall leave room for future in-app chat.
+- FR-FUT-002: The architecture shall leave room for future in-app audio/video calling.
+- FR-FUT-003: Future in-app communication shall be treated as a separate capability area requiring backend, identity, privacy, security, and moderation requirements.
+- FR-FUT-004: Future in-app communication events shall integrate with the same interaction-history model instead of creating a parallel history system.
+
+## 6. Data requirements
+
+### 6.1 Friend
+
+The existing `Friend` entity should be evolved carefully. Future implementation should consider replacing the raw `frequency: String` with a validated, migration-safe representation.
+
+Required friend-related data:
+
+- Friend ID.
+- Display name.
+- Phone number.
+- Email address.
+- Comments/notes.
+- Last-contacted date.
+- Reminder cadence.
+- Reminder enabled/disabled state.
+- Optional reminder snooze state.
+
+### 6.2 Reminder cadence
+
+The reminder cadence should support at least:
+
+- Weekly.
+- Monthly.
+- Custom number of days.
+
+Implementation may store cadence as:
+
+- enum + optional day count, or
+- integer days + display label.
+
+Acceptance requirement: invalid cadence values must not silently break reminder calculation.
+
+### 6.3 Interaction history
+
+Proposed entity: `InteractionHistory` or `ContactInteraction`.
+
+Minimum fields:
+
+- `id`: generated primary key.
+- `friendId`: foreign key to `Friend`.
+- `contactedAt`: timestamp or local date/time.
+- `channel`: enum/string such as `PHONE`, `SMS`, `EMAIL`, `WHATSAPP`, `IN_PERSON`, `OTHER`, future `IN_APP_CHAT`, future `IN_APP_CALL`.
+- `notes`: optional text.
+- `createdAt`: record creation timestamp if different from `contactedAt`.
+
+Recommended constraints:
+
+- Foreign-key relation to `Friend`.
+- Index on `friendId`.
+- Sort by `contactedAt DESC` for timeline display.
+
+## 7. Scheduling and notification requirements
+
+### 7.1 Scheduling
+
+- SR-SCHED-001: The system shall use an Android-supported scheduling mechanism for due-reminder checks.
+- SR-SCHED-002: WorkManager is the preferred default for periodic, battery-aware reminder checks.
+- SR-SCHED-003: Exact alarms should be avoided unless product requirements later demand exact time reminders and Android permission tradeoffs are accepted.
+- SR-SCHED-004: The scheduler shall be resilient across app restarts and device reboots within platform constraints.
+- SR-SCHED-005: The scheduler shall read reminder state from Room instead of relying only on in-memory state.
+
+### 7.2 Notifications
+
+- SR-NOTIF-001: The system shall create a notification channel for reminder notifications on Android versions that require channels.
+- SR-NOTIF-002: The system shall request or guide the user through notification permission requirements on Android 13+.
+- SR-NOTIF-003: Reminder notifications shall include the friend name and an action/deep link to the friend details screen.
+- SR-NOTIF-004: Notification content shall avoid exposing sensitive notes unless explicitly designed and approved.
+- SR-NOTIF-005: Notifications shall not repeatedly spam the same due friend without a state transition such as contacted, snoozed, next due date, or next daily digest window.
+
+## 8. External app integration requirements
+
+- SR-EXT-001: External communication should use Android intents rather than direct third-party SDKs for the first implementation.
+- SR-EXT-002: Phone calls should use the safest available intent flow first, such as opening the dialer with the number rather than requiring direct-call permission.
+- SR-EXT-003: SMS should open the default SMS app with the destination number and optional draft text if supported.
+- SR-EXT-004: Email should open an email intent with the destination address.
+- SR-EXT-005: WhatsApp should be launched through a package-aware or generic intent when available, with graceful fallback when not installed.
+- SR-EXT-006: The app shall not claim that communication happened just because an external intent was launched; history should be logged by explicit user confirmation or post-action prompt.
+
+## 9. Non-functional requirements
+
+- NFR-001 Maintainability: Feature work shall preserve the clean architecture separation between presentation, domain, and data layers.
+- NFR-002 Testability: Reminder date calculations and interaction-history use cases shall be unit tested without Android framework dependencies.
+- NFR-003 Reliability: Due-reminder calculation shall be deterministic for boundary cases such as today, overdue, leap days, and cadence changes.
+- NFR-004 Privacy: Contact data and interaction history shall remain local unless a future sync feature is explicitly designed and approved.
+- NFR-005 Battery awareness: Background checks shall respect Android background execution limits and avoid excessive wakeups.
+- NFR-006 Accessibility: Reminder/history UI should use clear labels and support standard Android accessibility behavior.
+- NFR-007 Compatibility: The app currently targets Android API 34 and supports minSdk 26; implementation should respect platform behavior across this range.
+- NFR-008 Migration safety: Room schema changes shall include migrations or a documented development-only fallback if destructive migration is intentionally accepted.
+
+## 10. Acceptance criteria summary
+
+The reminder/history feature set is accepted when:
+
+- A friend can have a valid reminder cadence.
+- The app can compute and display when that friend is due.
+- Background scheduling checks due reminders.
+- Android system notifications appear for due friends after permission/channel setup.
+- Notification taps route to the correct friend or relevant app screen.
+- The user can log contact interactions.
+- Contact history is persisted and visible per friend.
+- Marking a friend as contacted updates both `lastContacted` and interaction history.
+- External communication actions can launch appropriate apps and gracefully handle missing data/apps.
+- Documentation under `docs/` clearly separates existing, planned, and future capabilities.
+
+## 11. Open questions
+
+- Should reminders be exact-time reminders or approximate daily checks?
+- Should notifications be per-friend or a daily digest?
+- Should snooze be part of the first notification implementation?
+- Should interaction history be date-only or date-time?
+- Should external WhatsApp support require explicit user-provided WhatsApp numbers, or reuse phone numbers?
+- Should future in-app communication require accounts/sign-in, or remain out of scope until a backend is selected?


### PR DESCRIPTION
## Summary
- Adds system requirements for reminders, Android notifications, interaction history, external communication handoff, and future in-app chat/calling
- Adds phased feature roadmap under docs/
- Updates README to separate current implemented features from roadmap capabilities
- Moves local verification / NextCloud notes into docs/development-notes.md instead of keeping scout notes in README

## Test Plan
- Documentation-only change; no application code changed
- Reviewed generated Markdown diffs locally

## Notes
- No Gradle verification was run because this is documentation-only and the local Hermes host still needs Java/JDK configuration
